### PR TITLE
Added code to allow database drops

### DIFF
--- a/SQL Server/SQL_Basic_commands.ps1
+++ b/SQL Server/SQL_Basic_commands.ps1
@@ -34,7 +34,13 @@ Write-Host ($myNames | Format-Table | Out-String)
 $dropTable = "DROP TABLE $tableName"
 Invoke-Sqlcmd -server $server -Database $myDatabase -Query $dropTable
 
-# Remove database
-# This reports database currently in use. Probably something simple.
+# Remove database.
+# Without the first two commands the third command reports database in use.
+# Source for solution:
+# https://stackoverflow.com/questions/7469130/cannot-drop-database-because-it-is-currently-in-use
+$useMaster = "use master"
+Invoke-Sqlcmd -server $server -Query $useMaster
+$setSingleUser = "ALTER DATABASE $myDatabase SET SINGLE_USER WITH ROLLBACK IMMEDIATE"
+Invoke-Sqlcmd -server $server -Query $setSingleUser
 $dropDatabase = "DROP DATABASE $myDatabase"
 Invoke-Sqlcmd -server $server -Query $dropDatabase


### PR DESCRIPTION
Added code to allow dropping a database

Solves issue #42 

The issue was that when a drop was attempted the database was reported in use.
The added two commands switches database to master and sets the database to be dropped as single user.
When those commands have been performed the database can be dropped without errors.